### PR TITLE
[EVNT-195] Add micrometer to pom.xml

### DIFF
--- a/splunk-quarkus/pom.xml
+++ b/splunk-quarkus/pom.xml
@@ -122,6 +122,10 @@
             <artifactId>awaitility</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
By adding this, we are going to have default metrics path exposed at `/q/metrics`