### PR TITLE
[EVNT-234] Add Camel microprofile metrics and remove micrometer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 redhat-insights-*.*.*.tar.gz
 splunk/app/redhat-insights/local/
 splunk/app/redhat-insights/metadata/local.meta
-
+.vscode/
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/splunk-quarkus/pom.xml
+++ b/splunk-quarkus/pom.xml
@@ -110,7 +110,15 @@
             <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-jackson</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-micrometer</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+            <version>1.8.3</version>
+        </dependency>        
         <!-- Test -->
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -121,10 +129,6 @@
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
This PR adds Micrometer metrics with the default metrics exposed at `http://host:port/q/metrics` with the following metrics:

```
# HELP jvm_memory_used_bytes The amount of used memory
# TYPE jvm_memory_used_bytes gauge
jvm_memory_used_bytes{area="heap",id="G1 Survivor Space",} 6291456.0
jvm_memory_used_bytes{area="heap",id="G1 Old Gen",} 3.2486912E8
jvm_memory_used_bytes{area="nonheap",id="Metaspace",} 7.7080408E7
jvm_memory_used_bytes{area="nonheap",id="CodeHeap 'non-nmethods'",} 1406336.0
jvm_memory_used_bytes{area="heap",id="G1 Eden Space",} 1.32120576E8
jvm_memory_used_bytes{area="nonheap",id="Compressed Class Space",} 9795632.0
jvm_memory_used_bytes{area="nonheap",id="CodeHeap 'non-profiled nmethods'",} 1.511424E7
# HELP CamelExchangesFailed_total  
# TYPE CamelExchangesFailed_total counter
CamelExchangesFailed_total{camelContext="redhat-splunk-quarkus",routeId="route3",serviceName="MicrometerRoutePolicyService",} 0.0
CamelExchangesFailed_total{camelContext="redhat-splunk-quarkus",routeId="route2",serviceName="MicrometerRoutePolicyService",} 0.0
CamelExchangesFailed_total{camelContext="redhat-splunk-quarkus",routeId="route1",serviceName="MicrometerRoutePolicyService",} 0.0
# HELP jvm_classes_loaded_classes The number of classes that are currently loaded in the Java virtual machine
# TYPE jvm_classes_loaded_classes gauge
jvm_classes_loaded_classes 15217.0
# HELP jvm_memory_committed_bytes The amount of memory in bytes that is committed for the Java virtual machine to use
# TYPE jvm_memory_committed_bytes gauge
jvm_memory_committed_bytes{area="heap",id="G1 Survivor Space",} 6291456.0
jvm_memory_committed_bytes{area="heap",id="G1 Old Gen",} 6.48019968E8
jvm_memory_committed_bytes{area="nonheap",id="Metaspace",} 7.7791232E7
jvm_memory_committed_bytes{area="nonheap",id="CodeHeap 'non-nmethods'",} 2555904.0
jvm_memory_committed_bytes{area="heap",id="G1 Eden Space",} 4.5088768E8
jvm_memory_committed_bytes{area="nonheap",id="Compressed Class Space",} 1.0092544E7
jvm_memory_committed_bytes{area="nonheap",id="CodeHeap 'non-profiled nmethods'",} 1.5138816E7
# HELP jvm_gc_pause_seconds Time spent in GC pause
# TYPE jvm_gc_pause_seconds summary
jvm_gc_pause_seconds_count{action="end of minor GC",cause="Metadata GC Threshold",} 1.0
jvm_gc_pause_seconds_sum{action="end of minor GC",cause="Metadata GC Threshold",} 0.074
jvm_gc_pause_seconds_count{action="end of minor GC",cause="G1 Evacuation Pause",} 1.0
jvm_gc_pause_seconds_sum{action="end of minor GC",cause="G1 Evacuation Pause",} 0.009
# HELP jvm_gc_pause_seconds_max Time spent in GC pause
# TYPE jvm_gc_pause_seconds_max gauge
jvm_gc_pause_seconds_max{action="end of minor GC",cause="Metadata GC Threshold",} 0.074
jvm_gc_pause_seconds_max{action="end of minor GC",cause="G1 Evacuation Pause",} 0.009
# HELP jvm_classes_unloaded_classes_total The total number of classes unloaded since the Java virtual machine has started execution
# TYPE jvm_classes_unloaded_classes_total counter
jvm_classes_unloaded_classes_total 74.0
# HELP CamelExchangesSucceeded_total  
# TYPE CamelExchangesSucceeded_total counter
CamelExchangesSucceeded_total{camelContext="redhat-splunk-quarkus",routeId="route3",serviceName="MicrometerRoutePolicyService",} 0.0
CamelExchangesSucceeded_total{camelContext="redhat-splunk-quarkus",routeId="route2",serviceName="MicrometerRoutePolicyService",} 0.0
CamelExchangesSucceeded_total{camelContext="redhat-splunk-quarkus",routeId="route1",serviceName="MicrometerRoutePolicyService",} 0.0
# HELP process_files_open_files The open file descriptor count
# TYPE process_files_open_files gauge
process_files_open_files 433.0
# HELP system_cpu_count The number of processors available to the Java virtual machine
# TYPE system_cpu_count gauge
system_cpu_count 16.0
# HELP jvm_gc_overhead_percent An approximation of the percent of CPU time used by GC activities over the last lookback period or since monitoring began, whichever is shorter, in the range [0..1]
# TYPE jvm_gc_overhead_percent gauge
jvm_gc_overhead_percent 0.0013215511719810037
# HELP CamelExchangesTotal_total  
# TYPE CamelExchangesTotal_total counter
CamelExchangesTotal_total{camelContext="redhat-splunk-quarkus",routeId="route3",serviceName="MicrometerRoutePolicyService",} 0.0
CamelExchangesTotal_total{camelContext="redhat-splunk-quarkus",routeId="route2",serviceName="MicrometerRoutePolicyService",} 0.0
CamelExchangesTotal_total{camelContext="redhat-splunk-quarkus",routeId="route1",serviceName="MicrometerRoutePolicyService",} 0.0
# HELP jvm_memory_usage_after_gc_percent The percentage of long-lived heap pool used after the last GC event, in the range [0..1]
# TYPE jvm_memory_usage_after_gc_percent gauge
jvm_memory_usage_after_gc_percent{area="heap",pool="long-lived",} 0.07563948631286621
# HELP CamelExchangesFailuresHandled_total  
# TYPE CamelExchangesFailuresHandled_total counter
CamelExchangesFailuresHandled_total{camelContext="redhat-splunk-quarkus",routeId="route3",serviceName="MicrometerRoutePolicyService",} 0.0
CamelExchangesFailuresHandled_total{camelContext="redhat-splunk-quarkus",routeId="route2",serviceName="MicrometerRoutePolicyService",} 0.0
CamelExchangesFailuresHandled_total{camelContext="redhat-splunk-quarkus",routeId="route1",serviceName="MicrometerRoutePolicyService",} 0.0
# HELP jvm_gc_max_data_size_bytes Max size of long-lived heap memory pool
# TYPE jvm_gc_max_data_size_bytes gauge
jvm_gc_max_data_size_bytes 4.294967296E9
# HELP jvm_threads_daemon_threads The current number of live daemon threads
# TYPE jvm_threads_daemon_threads gauge
jvm_threads_daemon_threads 28.0
# HELP jvm_gc_memory_promoted_bytes_total Count of positive increases in the size of the old generation memory pool before GC to after GC
# TYPE jvm_gc_memory_promoted_bytes_total counter
jvm_gc_memory_promoted_bytes_total 5.099776E7
# HELP jvm_buffer_memory_used_bytes An estimate of the memory that the Java virtual machine is using for this buffer pool
# TYPE jvm_buffer_memory_used_bytes gauge
jvm_buffer_memory_used_bytes{id="mapped - 'non-volatile memory'",} 0.0
jvm_buffer_memory_used_bytes{id="mapped",} 0.0
jvm_buffer_memory_used_bytes{id="direct",} 74828.0
# HELP jvm_gc_live_data_size_bytes Size of long-lived heap memory pool after reclamation
# TYPE jvm_gc_live_data_size_bytes gauge
jvm_gc_live_data_size_bytes 0.0
# HELP jvm_buffer_total_capacity_bytes An estimate of the total capacity of the buffers in this pool
# TYPE jvm_buffer_total_capacity_bytes gauge
jvm_buffer_total_capacity_bytes{id="mapped - 'non-volatile memory'",} 0.0
jvm_buffer_total_capacity_bytes{id="mapped",} 0.0
jvm_buffer_total_capacity_bytes{id="direct",} 74826.0
# HELP jvm_memory_max_bytes The maximum amount of memory in bytes that can be used for memory management
# TYPE jvm_memory_max_bytes gauge
jvm_memory_max_bytes{area="heap",id="G1 Survivor Space",} -1.0
jvm_memory_max_bytes{area="heap",id="G1 Old Gen",} 4.294967296E9
jvm_memory_max_bytes{area="nonheap",id="Metaspace",} -1.0
jvm_memory_max_bytes{area="nonheap",id="CodeHeap 'non-nmethods'",} 1.216512E7
jvm_memory_max_bytes{area="heap",id="G1 Eden Space",} -1.0
jvm_memory_max_bytes{area="nonheap",id="Compressed Class Space",} 1.073741824E9
jvm_memory_max_bytes{area="nonheap",id="CodeHeap 'non-profiled nmethods'",} 2.3949312E8
# HELP CamelRoutesRunning_routes  
# TYPE CamelRoutesRunning_routes gauge
CamelRoutesRunning_routes{camelContext="redhat-splunk-quarkus",eventType="RouteEvent",serviceName="MicrometerEventNotifierService",} 3.0
# HELP CamelExchangesExternalRedeliveries_total  
# TYPE CamelExchangesExternalRedeliveries_total counter
CamelExchangesExternalRedeliveries_total{camelContext="redhat-splunk-quarkus",routeId="route3",serviceName="MicrometerRoutePolicyService",} 0.0
CamelExchangesExternalRedeliveries_total{camelContext="redhat-splunk-quarkus",routeId="route2",serviceName="MicrometerRoutePolicyService",} 0.0
CamelExchangesExternalRedeliveries_total{camelContext="redhat-splunk-quarkus",routeId="route1",serviceName="MicrometerRoutePolicyService",} 0.0
# HELP process_cpu_usage The "recent cpu usage" for the Java Virtual Machine process
# TYPE process_cpu_usage gauge
process_cpu_usage 0.0
# HELP process_files_max_files The maximum file descriptor count
# TYPE process_files_max_files gauge
process_files_max_files 10240.0
# HELP jvm_gc_memory_allocated_bytes_total Incremented for an increase in the size of the (young) heap memory pool after one GC to before the next
# TYPE jvm_gc_memory_allocated_bytes_total counter
jvm_gc_memory_allocated_bytes_total 5.64133888E8
# HELP jvm_threads_live_threads The current number of live threads including both daemon and non-daemon threads
# TYPE jvm_threads_live_threads gauge
jvm_threads_live_threads 68.0
# HELP jvm_threads_peak_threads The peak live thread count since the Java virtual machine started or peak was reset
# TYPE jvm_threads_peak_threads gauge
jvm_threads_peak_threads 68.0
# HELP jvm_threads_states_threads The current number of threads having NEW state
# TYPE jvm_threads_states_threads gauge
jvm_threads_states_threads{state="runnable",} 42.0
jvm_threads_states_threads{state="blocked",} 0.0
jvm_threads_states_threads{state="waiting",} 19.0
jvm_threads_states_threads{state="timed-waiting",} 7.0
jvm_threads_states_threads{state="new",} 0.0
jvm_threads_states_threads{state="terminated",} 0.0
# HELP jvm_info_total JVM version info
# TYPE jvm_info_total counter
jvm_info_total{runtime="OpenJDK Runtime Environment",vendor="Oracle Corporation",version="16+36-2231",} 1.0
# HELP CamelRoutesAdded_routes  
# TYPE CamelRoutesAdded_routes gauge
CamelRoutesAdded_routes{camelContext="redhat-splunk-quarkus",eventType="RouteEvent",serviceName="MicrometerEventNotifierService",} 3.0
# HELP process_start_time_seconds Start time of the process since unix epoch.
# TYPE process_start_time_seconds gauge
process_start_time_seconds 1.647372432501E9
# HELP system_load_average_1m The sum of the number of runnable entities queued to available processors and the number of runnable entities running on the available processors averaged over a period of time
# TYPE system_load_average_1m gauge
system_load_average_1m 1.80126953125
# HELP system_cpu_usage The "recent cpu usage" for the whole system
# TYPE system_cpu_usage gauge
system_cpu_usage 0.0
# HELP process_uptime_seconds The uptime of the Java virtual machine
# TYPE process_uptime_seconds gauge
process_uptime_seconds 75.504
# HELP http_server_connections_seconds_max  
# TYPE http_server_connections_seconds_max gauge
http_server_connections_seconds_max 0.061976432
# HELP http_server_connections_seconds  
# TYPE http_server_connections_seconds summary
http_server_connections_seconds_active_count 1.0
http_server_connections_seconds_duration_sum 0.061951956
# HELP jvm_buffer_count_buffers An estimate of the number of buffers in the pool
# TYPE jvm_buffer_count_buffers gauge
jvm_buffer_count_buffers{id="mapped - 'non-volatile memory'",} 0.0
jvm_buffer_count_buffers{id="mapped",} 0.0
jvm_buffer_count_buffers{id="direct",} 13.0
```