### PR TITLE
fix(Kafka): set groupId

### DIFF
--- a/splunk-quarkus/src/main/java/com/redhat/console/notifications/splunkintegration/SplunkIntegration.java
+++ b/splunk-quarkus/src/main/java/com/redhat/console/notifications/splunkintegration/SplunkIntegration.java
@@ -94,7 +94,7 @@ public class SplunkIntegration extends EndpointRouteBuilder {
     }
 
     private void configureIngress() throws Exception {
-        from(kafka(kafkaIngressTopic).brokers(kafkaBrokers).groupInstanceId(kafkaIngressGroupId))
+        from(kafka(kafkaIngressTopic).brokers(kafkaBrokers).groupId(kafkaIngressGroupId))
             // Decode CloudEvent
             .process(new CloudEventDecoder())
             // We check that this is our type.

--- a/splunk-quarkus/src/main/resources/application.properties
+++ b/splunk-quarkus/src/main/resources/application.properties
@@ -27,11 +27,11 @@ camel.context.name = redhat-splunk-quarkus
 
 # Kakfa ingress
 kafka.ingress.topic = platform.notifications.tocamel
-kafka.ingress.group.id = eventing
+kafka.ingress.group.id = eventing-splunk
 
 # Kafka bootstrap applies to all topics
 kafka.bootstrap.servers=localhost:9092
 
 # Kafka return channel
-kafka.return.group.id = eventing
+kafka.return.group.id = eventing-splunk
 kafka.return.topic = platform.notifications.fromcamel


### PR DESCRIPTION
Sets groupId instead of groupInstanceId which is intented for individual
instances within a group.

Fixes the error:
```
Error registering AppInfo mbean: javax.management.InstanceAlreadyExistsException: kafka.consumer:type=app-info,id=consumer-...
```

Note, that setting the group id is required for the multi-pod/instance deployments.

EVNT-226