### PR TITLE
[EVNT-44] Split the message by events

### DIFF
--- a/splunk-quarkus/pom.xml
+++ b/splunk-quarkus/pom.xml
@@ -75,6 +75,10 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-jsonpath</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-kafka</artifactId>
         </dependency>
         <dependency>

--- a/splunk-quarkus/src/main/java/com/redhat/console/notifications/splunkintegration/EventAppender.java
+++ b/splunk-quarkus/src/main/java/com/redhat/console/notifications/splunkintegration/EventAppender.java
@@ -1,0 +1,8 @@
+package com.redhat.console.notifications.splunkintegration;
+public class EventAppender {
+
+    public static String append(String existing, String next) {
+        return existing + next;
+    }
+
+}

--- a/splunk-quarkus/src/main/java/com/redhat/console/notifications/splunkintegration/EventPicker.java
+++ b/splunk-quarkus/src/main/java/com/redhat/console/notifications/splunkintegration/EventPicker.java
@@ -1,0 +1,36 @@
+package com.redhat.console.notifications.splunkintegration;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.Processor;
+import org.apache.camel.util.json.JsonObject;
+import org.apache.camel.util.json.JsonArray;
+import org.apache.camel.util.json.Jsoner;
+
+/**
+ * Transformer to pick an Event from the events
+ * of the message.
+ */
+public class EventPicker implements Processor {
+
+    public void process(Exchange exchange) throws Exception {
+
+        Message in = exchange.getIn();
+        String oldBody = in.getBody(String.class);
+        JsonObject jsonBody = (JsonObject) Jsoner.deserialize(oldBody);
+
+        JsonArray events = jsonBody.getCollection("events");
+        JsonArray newEvents = new JsonArray();
+
+        // asks Exchange for an index which is populated by a loop
+        Integer index = (Integer) exchange.getProperty("CamelLoopIndex");
+
+        newEvents.add(events.get(index));
+
+        jsonBody.put("events", newEvents);
+        String bodyAsJsonString = jsonBody.toJson();
+
+        in.setBody(bodyAsJsonString);
+    }
+
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/EVNT-44

This PR splits the `events` from the message into their own messages and then sends them to splunk as concatenated json strings (splunk accepts these and recognizes them correctly as separate messages).

It maintains current message schema as it leaves the `events` array in place with only one event per message now.