### PR TITLE
EVNT 329 kafka success message format

### DIFF
--- a/splunk-quarkus/src/main/java/com/redhat/console/notifications/splunkintegration/SplunkIntegration.java
+++ b/splunk-quarkus/src/main/java/com/redhat/console/notifications/splunkintegration/SplunkIntegration.java
@@ -120,7 +120,7 @@ public class SplunkIntegration extends EndpointRouteBuilder {
         Processor resultTransformer = new ResultTransformer();
         // If Event was sent successfully, send success reply to return kafka
         from(direct("success"))
-            .setBody(simple("Event ${header.ce-id} sent successfully"))
+            .setBody(simple("Success: Event ${header.ce-id} sent successfully"))
             .setHeader("outcome-fail", simple("false"))
             .process(resultTransformer)
             .marshal().json()

--- a/splunk-quarkus/src/main/java/com/redhat/console/notifications/splunkintegration/SplunkIntegration.java
+++ b/splunk-quarkus/src/main/java/com/redhat/console/notifications/splunkintegration/SplunkIntegration.java
@@ -116,10 +116,15 @@ public class SplunkIntegration extends EndpointRouteBuilder {
     }
 
     private void configureSuccessHandler() throws Exception {
+        Processor ceEncoder = new CloudEventEncoder(COMPONENT_NAME, RETURN_TYPE);
+        Processor resultTransformer = new ResultTransformer();
         // If Event was sent successfully, send success reply to return kafka
         from(direct("success"))
             .setBody(simple("Event ${header.ce-id} sent successfully"))
-            .setHeader("outcome-success", constant("true"))
+            .setHeader("outcome-fail", simple("false"))
+            .process(resultTransformer)
+            .marshal().json()
+            .process(ceEncoder)
             .to(direct("return"));
     }
 

--- a/splunk-quarkus/src/main/java/com/redhat/console/notifications/splunkintegration/SplunkIntegration.java
+++ b/splunk-quarkus/src/main/java/com/redhat/console/notifications/splunkintegration/SplunkIntegration.java
@@ -68,7 +68,7 @@ public class SplunkIntegration extends EndpointRouteBuilder {
     @ConfigProperty(name = "kafka.return.group.id")
     String kafkaReturnGroupId;
     // The return type
-    public static final String RETURN_TYPE = "com.redhat.console.notifications.error";
+    public static final String RETURN_TYPE = "com.redhat.console.notifications.history";
 
     @Override
     public void configure() throws Exception {


### PR DESCRIPTION
- [EVNT-329] Changes type of message to be returned to history
- [EVNT-329] Transforms the OK message into format for Notifications
- [EVNT-329] Adds "Success" prefix to OK message
