### PR TITLE
feat(clowder): parmetrize JAVA_OPTIONS

### DIFF
--- a/splunk-quarkus/Dockerfile.jvm
+++ b/splunk-quarkus/Dockerfile.jvm
@@ -31,7 +31,7 @@ RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
 
 ENV KAFKA_INGRESS_TOPIC="platform.notifications.tocamel"
 
-ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager\
+ENV JAVA_OPTIONS="-Djava.util.logging.manager=org.jboss.logmanager.LogManager\
  -Dquarkus.log.file.enable=false"
 
 # Use four distinct layers so if there are application changes the library layers can be re-used
@@ -43,6 +43,6 @@ COPY --from=build --chown=1001 /home/jboss/target/quarkus-app/quarkus/ /deployme
 EXPOSE 8080
 USER 1001
 
-ENTRYPOINT ["sh", "-c", "java $JAVA_OPTIONS \
+ENTRYPOINT ["sh", "-c", "java -Dquarkus.http.host=0.0.0.0 $JAVA_OPTIONS \
  -Dkafka.ingress.topic=$KAFKA_INGRESS_TOPIC\
  -jar /deployments/quarkus-run.jar "]

--- a/splunk-quarkus/clowdapp.yaml
+++ b/splunk-quarkus/clowdapp.yaml
@@ -64,6 +64,8 @@ objects:
         env:
         - name: QUARKUS_HTTP_PORT
           value: "${QUARKUS_HTTP_PORT}"
+        - name: JAVA_OPTIONS
+          value: "${JAVA_OPTIONS}"
         - name: KAFKA_INGRESS_TOPIC
           value: "${KAFKA_INGRESS_TOPIC}"
         resources:
@@ -92,6 +94,11 @@ parameters:
   - name: QUARKUS_HTTP_PORT
     description: "Listen port of the Quarkus, defaulting to default Clowder private port"
     value: "9000"
+  - name: JAVA_OPTIONS
+    description: "Custom JAVA options, like runtime parameters"
+    value: >-
+      -Djava.util.logging.manager=org.jboss.logmanager.LogManager
+      -Dquarkus.log.file.enable=false
   - name: KAFKA_INGRESS_TOPIC
     description: Kafka topic that the consumer takes messages from
     value: platform.notifications.tocamel


### PR DESCRIPTION
For example for occasional debugging.

We can later add this for the HTTP issues:
```
-Dquarkus.log.category.\"org.apache.http.impl.conn\".level=DEBUG
```

EVNT-431, EVNT-315