### PR TITLE
fix(http): non-dynamic http routes and idle connection eviction

### DIFF
--- a/splunk-quarkus/src/main/java/com/redhat/console/notifications/splunkintegration/SplunkIntegration.java
+++ b/splunk-quarkus/src/main/java/com/redhat/console/notifications/splunkintegration/SplunkIntegration.java
@@ -206,13 +206,15 @@ public class SplunkIntegration extends EndpointRouteBuilder {
             // It sends token via Basic Preemptive Authentication.
             // POST method is being used, set up explicitly
             // (see https://camel.apache.org/components/latest/http-component.html#_which_http_method_will_be_used).
+            .setHeader(Exchange.HTTP_URI, simple("$simple{headers.metadata[url]}"))
+            .setHeader(Exchange.HTTP_PATH, constant("/services/collector/event"))
             .choice()
                 .when(simple("${headers.metadata[url]} startsWith 'http://'"))
-                    .toD(http("$simple{headers.metadata[url].replaceFirst('^http://', '')}/services/collector/event")
+                    .to(http("dynamic")
                         .httpMethod("POST"))
                     .endChoice()
                 .otherwise()
-                    .toD(https("$simple{headers.metadata[url].replaceFirst('^https://', '')}/services/collector/event")
+                    .to(https("dynamic")
                         .httpMethod("POST"))
                     .endChoice()
             .end()


### PR DESCRIPTION
This refactors and fixes the http(s) integration by using only two
routes (http and https) instead of having them created dynamically.
This is possible by leveraging HTTP_URI and HTTP_PATH headers.

This has couple of advantages:
* it creates single instances of http camel components
* one connection pool for each instance (http and https)
* with one registry
* allows to share the connection and manage them better
* reduces overall resources

Adds idle connection eviction on connection manager(s).
It proactively evict idle connections from the connection pool *after 5s* using a background thread.
Arguments set maximum time persistent connections can stay idle while kept alive in the connection pool.
Connections whose inactivity period exceeds this value will get closed and evicted from the pool.

Hopefully this would fix the Connection reset. I guess they could have existed because of the dynamic camel routing creating a fresh new component for each integration with new pool.

EVNT-437