### PR TITLE
[EVNT-348][EVNT-455] Update Quarkus to 2.8.3 with all dependencies and fix deprecation

### DIFF
--- a/splunk-quarkus/pom.xml
+++ b/splunk-quarkus/pom.xml
@@ -28,7 +28,7 @@
     <description>Red Hat 3rd party Eventing</description>
 
     <properties>
-        <quarkus.platform.version>2.3.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.8.3.Final</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
@@ -122,7 +122,7 @@
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
             <version>1.8.3</version>
-        </dependency>        
+        </dependency>
         <!-- Test -->
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/splunk-quarkus/src/main/java/com/redhat/console/notifications/splunkintegration/CloudEventEncoder.java
+++ b/splunk-quarkus/src/main/java/com/redhat/console/notifications/splunkintegration/CloudEventEncoder.java
@@ -1,10 +1,5 @@
 package com.redhat.console.notifications.splunkintegration;
 
-import org.apache.camel.Exchange;
-import org.apache.camel.Message;
-import org.apache.camel.Processor;
-import org.apache.camel.util.json.JsonObject;
-
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -12,6 +7,11 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.Processor;
+import org.apache.camel.util.json.JsonObject;
 
 /**
  * Encode the passed body in a CloudEvent, marshalled as Json

--- a/splunk-quarkus/src/main/java/com/redhat/console/notifications/splunkintegration/EventPicker.java
+++ b/splunk-quarkus/src/main/java/com/redhat/console/notifications/splunkintegration/EventPicker.java
@@ -3,8 +3,8 @@ package com.redhat.console.notifications.splunkintegration;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.Processor;
-import org.apache.camel.util.json.JsonObject;
 import org.apache.camel.util.json.JsonArray;
+import org.apache.camel.util.json.JsonObject;
 import org.apache.camel.util.json.Jsoner;
 
 /**

--- a/splunk-quarkus/src/main/java/com/redhat/console/notifications/splunkintegration/ResultTransformer.java
+++ b/splunk-quarkus/src/main/java/com/redhat/console/notifications/splunkintegration/ResultTransformer.java
@@ -1,11 +1,11 @@
 package com.redhat.console.notifications.splunkintegration;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.Processor;
-
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * Transformer to create a Map from the outcome of the actual component.

--- a/splunk-quarkus/src/main/java/com/redhat/console/notifications/splunkintegration/SplunkIntegration.java
+++ b/splunk-quarkus/src/main/java/com/redhat/console/notifications/splunkintegration/SplunkIntegration.java
@@ -29,7 +29,7 @@ import org.apache.camel.Processor;
 import org.apache.camel.Exchange;
 import org.apache.camel.model.dataformat.JsonLibrary;
 import org.apache.camel.builder.AggregationStrategies;
-import org.apache.camel.http.common.HttpOperationFailedException;
+import org.apache.camel.http.base.HttpOperationFailedException;
 import org.apache.camel.component.http.HttpClientConfigurer;
 import org.apache.camel.LoggingLevel;
 

--- a/splunk-quarkus/src/main/java/com/redhat/console/notifications/splunkintegration/SplunkIntegration.java
+++ b/splunk-quarkus/src/main/java/com/redhat/console/notifications/splunkintegration/SplunkIntegration.java
@@ -16,22 +16,22 @@
  */
 package com.redhat.console.notifications.splunkintegration;
 
-import io.quarkus.runtime.annotations.RegisterForReflection;
-import org.eclipse.microprofile.config.Config;
-import org.eclipse.microprofile.config.ConfigProvider;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
-import javax.enterprise.context.ApplicationScoped;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.camel.builder.endpoint.EndpointRouteBuilder;
-import org.apache.camel.Processor;
+import javax.enterprise.context.ApplicationScoped;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import org.apache.camel.Exchange;
-import org.apache.camel.model.dataformat.JsonLibrary;
-import org.apache.camel.builder.AggregationStrategies;
-import org.apache.camel.http.base.HttpOperationFailedException;
-import org.apache.camel.component.http.HttpClientConfigurer;
 import org.apache.camel.LoggingLevel;
+import org.apache.camel.Processor;
+import org.apache.camel.builder.endpoint.EndpointRouteBuilder;
+import org.apache.camel.component.http.HttpClientConfigurer;
+import org.apache.camel.http.base.HttpOperationFailedException;
+import org.apache.camel.model.dataformat.JsonLibrary;
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 /**
  * The main class that does the work setting up the Camel routes. Entry point for messages is below


### PR DESCRIPTION
Updates Quarkus platform version to `2.8.3.Final`.
Fixes the deprecation warning of `org.apache.camel.http.common.HttpOperationFailedException` that turned out to be an error during update to a newer version.
And lastly reorders imports, as per auto-formatter.

EVNT-348, EVNT-455