### PR TITLE
[WIP] [EVNT-409] Setting redelivery values

### DIFF
--- a/splunk-quarkus/src/main/java/com/redhat/console/notifications/splunkintegration/SplunkIntegration.java
+++ b/splunk-quarkus/src/main/java/com/redhat/console/notifications/splunkintegration/SplunkIntegration.java
@@ -92,9 +92,15 @@ public class SplunkIntegration extends EndpointRouteBuilder {
 
     private void configureErrorHandler() throws Exception {
         onException(IOException.class)
+                .maximumRedilveries(3)
+                .useExponentialBackOff(true)
+                .useCollisionAvoidance(true)
                 .to(direct("ioFailed"))
                 .handled(true);
         onException(HttpOperationFailedException.class)
+                .maximumRedilveries(3)
+                .useExponentialBackOff(true)
+                .useCollisionAvoidance(true)
                 .to(direct("httpFailed"))
                 .handled(true);
     }


### PR DESCRIPTION
Several questions:
- https://camel.apache.org/manual/exception-clause.html#_configuring_redeliverypolicy_redeliver_options states that "RedeliveryPolicy requires to use the Dead Letter Channel as the Error Handler." but then goes on to set maximumRedeliveries without explicitly declaring the Dead Letter Channel.  vkrizan provided the above resource link but then said he'd rather not use the Dead Letter Channel; I'm not sure this is possible.
- In discussion with msager, it sounds like if we could configure the retries with values set on the pods that could be helpful for testing to manually adjust the various options. Is this doable or overly complex?
- Also, if we were to save the original pre-transformation body/metadata of messages that failed to deliver after exhausting all retries, these could be manually processed later; not sure if this is desirable for longer outages or not feasible given the large number of events going through (are they stored in a DB that we'd then have to manage? for how long? what's the security/data privacy implications?) The option is discussed here: https://camel.apache.org/components/3.16.x/eips/dead-letter-channel.html#_moving_the_original_message_to_the_dead_letter_queue
- After exhausting all redelivery attempts, how do we go not with the dead letter channel logging but pass along to our existing Http vs IO exception logging message options?  Do we just redefine those as dead letter channel exceptionHandlers?  My current attempt I fear will always log failure even if redelivery succeeds, and if I add .end() after the redelivery, I don't how to configure the logging on failure the way we prefer.  Perhaps an onWhen() and use a counter with it for retries unless there's a bool somewhere that gets flipped when retries are finished.  There's retriesExhaustedLogLevel but not just retriesExhausted itself, at least that I've been able to find so far. (See options here: https://www.javadoc.io/doc/org.apache.camel/camel-core-processor/latest/org/apache/camel/processor/errorhandler/RedeliveryPolicy.html)