### PR TITLE
fix(exchange): filter out message headers for HTTP

### DIFF
--- a/splunk-quarkus/src/main/java/com/redhat/console/notifications/splunkintegration/SplunkIntegration.java
+++ b/splunk-quarkus/src/main/java/com/redhat/console/notifications/splunkintegration/SplunkIntegration.java
@@ -17,6 +17,7 @@
 package com.redhat.console.notifications.splunkintegration;
 
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.concurrent.TimeUnit;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -28,6 +29,7 @@ import org.apache.camel.Processor;
 import org.apache.camel.builder.endpoint.EndpointRouteBuilder;
 import org.apache.camel.component.http.HttpClientConfigurer;
 import org.apache.camel.http.base.HttpOperationFailedException;
+import org.apache.camel.http.common.HttpHeaderFilterStrategy;
 import org.apache.camel.model.dataformat.JsonLibrary;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
@@ -75,6 +77,18 @@ public class SplunkIntegration extends EndpointRouteBuilder {
     String kafkaReturnGroupId;
     // The return type
     public static final String RETURN_TYPE = "com.redhat.console.notifications.history";
+
+    class SplunkHttpHeaderStrategy extends HttpHeaderFilterStrategy {
+        @Override
+        protected void initialize() {
+            setLowerCase(true);
+            setFilterOnMatch​(false); // reverse filtering to only accept selected
+
+            getInFilter().clear();
+            getOutFilter().clear();
+            getOutFilter().add("authorization");
+        }
+    }
 
     @Override
     public void configure() throws Exception {
@@ -218,12 +232,14 @@ public class SplunkIntegration extends EndpointRouteBuilder {
                 .when(simple("${headers.metadata[url]} startsWith 'http://'"))
                 .to(http("dynamic")
                         .httpMethod("POST")
+                        .headerFilterStrategy(new SplunkHttpHeaderStrategy())
                         .advanced()
                         .httpClientConfigurer(getClientConfigurer()))
                 .endChoice()
                 .otherwise()
                 .to(https("dynamic")
                         .httpMethod("POST")
+                        .headerFilterStrategy(new SplunkHttpHeaderStrategy())
                         .advanced()
                         .httpClientConfigurer(getClientConfigurer()))
                 .endChoice()


### PR DESCRIPTION
Only passes `Authorization` header to HTTP POST requests. Everything else is filtered out.

Diff:
```diff
 POST /services/collector/event HTTP/1.1
 Authorization: Splunk TOKENTOKEN
-Ce-id: 9dc9a4b1-8868-4afc-a69d-e8723b20452c
-Ce-rh-account: 12345
-Ce-source: notifications
-Ce-specversion: 1.0
-Ce-time: 2022-02-02T14:09:55.532551Z
-Ce-type: com.redhat.console.notification.toCamel.splunk
-kafka.OFFSET: 8
-kafka.PARTITION: 0
-kafka.TIMESTAMP: 1653407064890
-kafka.TOPIC: platform.notifications.tocamel
-metadata: [url=URLURL, X-Insight-Token=TOKENTOKEN, extras={}]
-targetUrl: URLURL
-timeIn: 1653407056499
```

EVNT-439