### PR TITLE
[EVNT-425] - Integration should accept all CA certs when trustAll is true

### DIFF
--- a/splunk-quarkus/src/main/java/com/redhat/console/notifications/splunkintegration/SplunkIntegration.java
+++ b/splunk-quarkus/src/main/java/com/redhat/console/notifications/splunkintegration/SplunkIntegration.java
@@ -31,6 +31,9 @@ import org.apache.camel.component.http.HttpClientConfigurer;
 import org.apache.camel.http.base.HttpOperationFailedException;
 import org.apache.camel.http.common.HttpHeaderFilterStrategy;
 import org.apache.camel.model.dataformat.JsonLibrary;
+import org.apache.camel.support.jsse.SSLContextParameters;
+import org.apache.camel.support.jsse.TrustManagersParameters;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -240,6 +243,16 @@ public class SplunkIntegration extends EndpointRouteBuilder {
                         .httpClientConfigurer(getClientConfigurer()))
                 .endChoice()
                 .otherwise()
+                .when(simple("${headers.metadata[trustAll]} == 'true'"))
+                .to(https("dynamic")
+                        .sslContextParameters(getTrustAllCACerts())
+                        .x509HostnameVerifier(NoopHostnameVerifier.INSTANCE)
+                        .httpMethod("POST")
+                        .headerFilterStrategy(new SplunkHttpHeaderStrategy())
+                        .advanced()
+                        .httpClientConfigurer(getClientConfigurer()))
+                .endChoice()
+                .otherwise()
                 .to(https("dynamic")
                         .httpMethod("POST")
                         .headerFilterStrategy(new SplunkHttpHeaderStrategy())
@@ -248,6 +261,15 @@ public class SplunkIntegration extends EndpointRouteBuilder {
                 .endChoice()
                 .end()
                 .to(direct("success"));
+    }
+
+    protected SSLContextParameters getTrustAllCACerts() {
+        TrustManagersParameters trustManagersParameters = new TrustManagersParameters();
+        trustManagersParameters.setTrustManager(new SplunkTrustAllCACerts());
+        SSLContextParameters sslContextParameters = new SSLContextParameters();
+        sslContextParameters.setTrustManagers(trustManagersParameters);
+
+        return sslContextParameters;
     }
 
     protected HttpClientConfigurer getClientConfigurer() {

--- a/splunk-quarkus/src/main/java/com/redhat/console/notifications/splunkintegration/SplunkTrustAllCACerts.java
+++ b/splunk-quarkus/src/main/java/com/redhat/console/notifications/splunkintegration/SplunkTrustAllCACerts.java
@@ -1,0 +1,22 @@
+package com.redhat.console.notifications.splunkintegration;
+
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+import javax.net.ssl.X509TrustManager;
+
+class SplunkTrustAllCACerts implements X509TrustManager {
+
+    public void checkClientTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+
+    }
+
+    public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+
+    }
+
+    public X509Certificate[] getAcceptedIssuers() {
+        return null;
+    }
+
+}


### PR DESCRIPTION
[EVNT-425](https://issues.redhat.com/browse/EVNT-425)

Now, we verify the if `Enable SSL verification` is selected in Integrations, and route the HTTPS requests based on `trustAll` field in metadata.

Test cases:
1) Have HEC SSL `enabled` in Splunk 
    a) Send an HTTPS request with `trustAll` as `true`. You should see a success call.
    b) Send an HTTPS request with `trustAll` as `false`. It should fail, as we do not have a certificate properly set.
    

2)  Have HEC SSL `disabled` in Splunk
    a) Send an HTTPS request with `trustAll` as `true`. You should see: `Failed cloud event, id 9dc9a4b1-8868-4afc-a69d-e8723b20452c, with IO exception : Unsupported or unrecognized SSL message`.
    b) Send an HTTP request with `trustAll` as `true` or `false`. You should see a success call.