### PR TITLE
[EVNT-171] feat: cloudwatch logging

### DIFF
--- a/splunk-quarkus/devel.json
+++ b/splunk-quarkus/devel.json
@@ -16,5 +16,9 @@
                 "consumerGroup": "Eventing"
             }
         ]
+    },
+    "logging": {
+        "cloudwatch": {},
+        "type": "none"
     }
 }

--- a/splunk-quarkus/pom.xml
+++ b/splunk-quarkus/pom.xml
@@ -113,7 +113,7 @@
         <dependency>
             <groupId>com.redhat.cloud.common</groupId>
             <artifactId>clowder-quarkus-config-source</artifactId>
-            <version>0.4.0</version>
+            <version>1.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/splunk-quarkus/pom.xml
+++ b/splunk-quarkus/pom.xml
@@ -113,7 +113,12 @@
         <dependency>
             <groupId>com.redhat.cloud.common</groupId>
             <artifactId>clowder-quarkus-config-source</artifactId>
-            <version>1.0.0</version>
+            <version>1.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.logging.cloudwatch</groupId>
+            <artifactId>quarkus-logging-cloudwatch</artifactId>
+            <version>4.3.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>


### PR DESCRIPTION
Adds in [quarkus-logging-cloudwatch](https://github.com/quarkiverse/quarkus-logging-cloudwatch) extension witch is being configured by Clowder (via clowder-quarkus-config-source).

Also updates the [clowder-quarkus-config-source](https://github.com/RedHatInsights/clowder-quarkus-config-source) to latest version 1.0.0.

Unfortunately we can safely test this only on stage environment.

EVNT-171