### PR TITLE
[EVNT-171] fix(logging): set log stream name for cloudwatch 

### DIFF
--- a/splunk-quarkus/pom.xml
+++ b/splunk-quarkus/pom.xml
@@ -118,7 +118,7 @@
         <dependency>
             <groupId>io.quarkiverse.logging.cloudwatch</groupId>
             <artifactId>quarkus-logging-cloudwatch</artifactId>
-            <version>4.3.0</version>
+            <version>4.3.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/splunk-quarkus/src/main/resources/application.properties
+++ b/splunk-quarkus/src/main/resources/application.properties
@@ -20,6 +20,9 @@
 quarkus.banner.enabled = false
 quarkus.log.file.enable = true
 
+# Logging
+quarkus.log.cloudwatch.log-stream-name=eventing-splunk-quarkus
+
 #
 # Camel
 #


### PR DESCRIPTION
Sets required `quarkus.log.cloudwatch.log-stream-name` to `eventing-splunk-quarkus`.
Updates the `quarkus-logging-cloudwatch` package to have info logging when cloudwatch logging is set to be disabled.