### PR TITLE
fix(logging): different log-stream per pod

### DIFF
--- a/splunk-quarkus/clowdapp.yaml
+++ b/splunk-quarkus/clowdapp.yaml
@@ -64,6 +64,8 @@ objects:
         env:
         - name: QUARKUS_HTTP_PORT
           value: "${QUARKUS_HTTP_PORT}"
+        - name: QUARKUS_LOG_CLOUDWATCH_LOG_STREAM_NAME
+          value: ${HOSTNAME}
         - name: JAVA_OPTIONS
           value: "${JAVA_OPTIONS}"
         - name: KAFKA_INGRESS_TOPIC


### PR DESCRIPTION
Cloudwatch needs log-streams per instance that pushes the logs.  This
fixes it by setting the log-stream via env var to pod's hostname.

EVNT-171