### PR TITLE
feat(kafka): autoconfiguration with security and authentication

### DIFF
--- a/splunk-quarkus/pom.xml
+++ b/splunk-quarkus/pom.xml
@@ -113,7 +113,7 @@
         <dependency>
             <groupId>com.redhat.cloud.common</groupId>
             <artifactId>clowder-quarkus-config-source</artifactId>
-            <version>1.0.2</version>
+            <version>1.2.0</version>
         </dependency>
         <dependency>
             <groupId>io.quarkiverse.logging.cloudwatch</groupId>

--- a/splunk-quarkus/src/main/java/com/redhat/console/notifications/splunkintegration/SplunkIntegration.java
+++ b/splunk-quarkus/src/main/java/com/redhat/console/notifications/splunkintegration/SplunkIntegration.java
@@ -196,7 +196,7 @@ public class SplunkIntegration extends EndpointRouteBuilder {
     }
 
     private void configureIngress() throws Exception {
-        from(kafka(kafkaIngressTopic).brokers(kafkaBrokers).groupId(kafkaIngressGroupId))
+        from(kafka(kafkaIngressTopic).groupId(kafkaIngressGroupId))
                 .routeId("ingress")
                 // Decode CloudEvent
                 .process(new CloudEventDecoder())
@@ -212,7 +212,7 @@ public class SplunkIntegration extends EndpointRouteBuilder {
     private void configureReturn() throws Exception {
         from(direct("return"))
                 .routeId("return")
-                .to(kafka(kafkaReturnTopic).brokers(kafkaBrokers));
+                .to(kafka(kafkaReturnTopic));
     }
 
     private void configureSuccessHandler() throws Exception {

--- a/splunk-quarkus/src/main/resources/application.properties
+++ b/splunk-quarkus/src/main/resources/application.properties
@@ -33,8 +33,8 @@ camel.context.name = redhat-splunk-quarkus
 kafka.ingress.topic = platform.notifications.tocamel
 kafka.ingress.group.id = eventing-splunk
 
-# Kafka bootstrap applies to all topics
-kafka.bootstrap.servers=localhost:9092
+# Kafka component configuration
+camel.component.kafka.brokers = localhost:9092
 
 # Kafka return channel
 kafka.return.group.id = eventing-splunk

--- a/splunk-quarkus/src/main/resources/application.properties
+++ b/splunk-quarkus/src/main/resources/application.properties
@@ -35,6 +35,11 @@ kafka.ingress.group.id = eventing-splunk
 
 # Kafka component configuration
 camel.component.kafka.brokers = localhost:9092
+camel.component.kafka.sasl-jaas-config = ""
+camel.component.kafka.sasl-mechanism = GSSAPI
+camel.component.kafka.security-protocol = PLAINTEXT
+camel.component.kafka.ssl-truststore-location = ""
+camel.component.kafka.ssl-truststore-type = JKS
 
 # Kafka return channel
 kafka.return.group.id = eventing-splunk


### PR DESCRIPTION
**Depends on https://github.com/RedHatInsights/clowder-quarkus-config-source/pull/96**

Updates `clowder-quarkus-config-source` dependency to leverage autoconfiguration of Kafka component.
The autoconfiguation is enabled by setting props to `application.properties`. Camel Kafka default values are set. Official values are populated by the library from Clowder config in the initialization.

This autoconfigures:
* brokers
* security protocol
* SASL authentication
* certificates

EVNT-557 