### PR TITLE
chore(ci): reorganize pr_check and delpoy scripts for new repo

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Adapted from: https://github.com/RedHatInsights/drift-backend/blob/master/build_deploy.sh
+
+set -exv
+
+IMAGE_NAME="quay.io/cloudservices/eventing-integrations-splunk"
+IMAGE_TAG=$(git rev-parse --short=7 HEAD)
+
+if [[ -z "$QUAY_USER" || -z "$QUAY_TOKEN" ]]; then
+    echo "QUAY_USER and QUAY_TOKEN must be set"
+    exit 1
+fi
+
+if test -f /etc/redhat-release && grep -q -i "release 7" /etc/redhat-release; then
+    # on RHEL7, use docker
+    DOCKER_CONF="$PWD/.docker"
+    mkdir -p "$DOCKER_CONF"
+    docker --config="$DOCKER_CONF" login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
+    #docker --config="$DOCKER_CONF" login -u="$RH_REGISTRY_USER" -p="$RH_REGISTRY_TOKEN" registry.redhat.io
+    docker --config="$DOCKER_CONF" build -f ./splunk-quarkus/Dockerfile.jvm -t "${IMAGE_NAME}:${IMAGE_TAG}" .
+    docker --config="$DOCKER_CONF" push "${IMAGE_NAME}:${IMAGE_TAG}"
+    for TAG in "latest" "qa"; do
+        docker --config="$DOCKER_CONF" tag "${IMAGE_NAME}:${IMAGE_TAG}" "${IMAGE_NAME}:$TAG"
+        docker --config="$DOCKER_CONF" push "${IMAGE_NAME}:$TAG"
+    done
+else
+    # on RHEL8 or anything else, use podman
+    AUTH_CONF_DIR="$(pwd)/.podman"
+    mkdir -p $AUTH_CONF_DIR
+    export REGISTRY_AUTH_FILE="$AUTH_CONF_DIR/auth.json"
+    podman login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
+    #podman login -u="$RH_REGISTRY_USER" -p="$RH_REGISTRY_TOKEN" registry.redhat.io
+    podman build -f ./splunk-quarkus/Dockerfile.jvm -t "${IMAGE_NAME}:${IMAGE_TAG}" .
+    podman push "${IMAGE_NAME}:${IMAGE_TAG}"
+    for TAG in "latest" "qa"; do
+        podman tag "${IMAGE_NAME}:${IMAGE_TAG}" "${IMAGE_NAME}:$TAG"
+        podman push "${IMAGE_NAME}:$TAG"
+    done
+fi

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -4,7 +4,7 @@
 
 set -exv
 
-IMAGE_NAME="quay.io/cloudservices/eventing-integrations-splunk"
+IMAGE_NAME="quay.io/cloudservices/eventing-integrations"
 IMAGE_TAG=$(git rev-parse --short=7 HEAD)
 
 if [[ -z "$QUAY_USER" || -z "$QUAY_TOKEN" ]]; then

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -7,7 +7,7 @@
 # --------------------------------------------
 APP_NAME="eventing"  # name of app-sre "application" folder this component lives in
 COMPONENT_NAME="eventing-splunk-quarkus"  # name of app-sre "resourceTemplate" in deploy.yaml for this component
-IMAGE="quay.io/cloudservices/eventing-integrations-splunk"
+IMAGE="quay.io/cloudservices/eventing-integrations"
 DOCKERFILE="splunk-quarkus/Dockerfile.jvm"
 
 # Enviroment to take bonfire/clowdapp reources from

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+#Adapted from https://github.com/RedHatInsights/insights-ingress-go/blob/master/pr_check.sh
+
+# --------------------------------------------
+# Options that must be configured by app owner
+# --------------------------------------------
+APP_NAME="eventing"  # name of app-sre "application" folder this component lives in
+COMPONENT_NAME="eventing-splunk-quarkus"  # name of app-sre "resourceTemplate" in deploy.yaml for this component
+IMAGE="quay.io/cloudservices/eventing-integrations-splunk"
+DOCKERFILE="splunk-quarkus/Dockerfile.jvm"
+
+# Enviroment to take bonfire/clowdapp reources from
+export REF_ENV="insights-stage"
+
+IQE_PLUGINS="eventing"
+IQE_MARKER_EXPRESSION="smoke" # Need to check this
+IQE_FILTER_EXPRESSION=""
+IQE_CJI_TIMEOUT="30m"
+
+
+# Install bonfire repo/initialize
+CICD_URL=https://raw.githubusercontent.com/RedHatInsights/bonfire/master/cicd
+curl -s $CICD_URL/bootstrap.sh > .cicd_bootstrap.sh && source .cicd_bootstrap.sh
+source $CICD_ROOT/build.sh
+
+export COMPONENTS_W_RESOURCES="policies-engine"
+source $CICD_ROOT/deploy_ephemeral_env.sh
+
+source $CICD_ROOT/cji_smoke_test.sh


### PR DESCRIPTION
Copies out the `pr_check.sh` and `build_deploy.sh` scripts to root and changes them to use new common Quay.io repository.

EVNT-613