### PR TITLE
fix(kafka): SSL connection w/o pinned CA

### DIFF
--- a/splunk-quarkus/src/main/resources/application.properties
+++ b/splunk-quarkus/src/main/resources/application.properties
@@ -41,7 +41,7 @@ camel.component.kafka.brokers = localhost:9092
 camel.component.kafka.sasl-jaas-config = ""
 camel.component.kafka.sasl-mechanism = GSSAPI
 camel.component.kafka.security-protocol = PLAINTEXT
-camel.component.kafka.ssl-truststore-location = ""
+camel.component.kafka.ssl-truststore-location =
 camel.component.kafka.ssl-truststore-type = JKS
 
 


### PR DESCRIPTION
This fixes case when `cacert` is not provided from Clowder config in
case of SSL Kafka connection.

EVNT-668