### PR TITLE
ci: rebuild image on package updates

### DIFF
--- a/.github/workflows/checkimage.yaml
+++ b/.github/workflows/checkimage.yaml
@@ -1,0 +1,30 @@
+name: Regular base image update check
+on:
+  schedule:
+    - cron: "5 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install skopeo
+        run: sudo apt-get install -y skopeo
+      - name: Check change
+        run: |
+          skopeo inspect "docker://registry.access.redhat.com/ubi8/ubi-minimal" | grep -Po '(?<="Digest": ")([^"]+)' > .baseimagedigest
+          docker run --rm --entrypoint sh -u 0 quay.io/cloudservices/eventing-integrations:latest -c \
+            'microdnf update > /dev/null; rpm -qa | sort | sha256sum' \
+            >> .baseimagedigest
+      - name: Do change if the digest changed
+        run: |
+          git config user.name 'Update-a-Bot'
+          git config user.email 'insights@redhat.com'
+          git add .baseimagedigest
+          git commit -m "chore(image): update and rebuild image" || echo "No new changes"
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          title: 'chore(image): update base image'


### PR DESCRIPTION
Creates a daily automation that tracks base image digest and package list digest.
Once there is a change in either in base image or in installed packages, the automation create a pull request with new digest(s). Merging such PR would trigger a new image build.

EVNT-669