### PR TITLE
chore: Introduce dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "maven"
+    directory: "/splunk-quarkus"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This PR introduces [dependabot](https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/) to make sure all Maven dependencies as well as GitHub actions are always up-to-date.