### PR TITLE
feat improve backlog resiliency

### DIFF
--- a/splunk-quarkus/src/main/resources/application.properties
+++ b/splunk-quarkus/src/main/resources/application.properties
@@ -35,6 +35,12 @@ camel.context.name = eventing-${integrations.component.name}
 # INTEGRATION_NAME_PATTERN should be like: **/Splunk*, **/ServiceNow*, etc...
 camel.main.javaRoutesIncludePattern = **/MainRoutes*,**/ErrorHandlingRoutes*,**/Splunk*
 
+# HTTP component configuartion
+# timeout in milliseconds until a connection is established
+camel.component.http.connect-timeout = 2500
+# the socket timeout in milliseconds, which is the timeout for waiting for data
+camel.component.http.socket-timeout = 2500
+
 
 # Kafka component configuration
 camel.component.kafka.brokers = localhost:9092

--- a/splunk-quarkus/src/main/resources/application.properties
+++ b/splunk-quarkus/src/main/resources/application.properties
@@ -49,6 +49,7 @@ camel.component.kafka.sasl-mechanism = GSSAPI
 camel.component.kafka.security-protocol = PLAINTEXT
 camel.component.kafka.ssl-truststore-location =
 camel.component.kafka.ssl-truststore-type = JKS
+camel.component.kafka.max-poll-records = 300
 
 
 # Managed Kafka topics


### PR DESCRIPTION
Reduces Kafka poll() records to 30 and sets http connection timeout.

This should improve resiliency when there is a higher kafka backlog, to
prevent the consumer being kicked out due to inactivity (timeouted poll).

EVNT-789