### PR TITLE
fix: route switching w/ downgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,9 @@ The platform version is mapped to a set of dependent packages of Camel provided 
 package [`io.quarkus.platform:quarkus-camel-bom`][quarkus-camel-bom]
 (available from [quarkusio/quarkus-platform](https://github.com/quarkusio/quarkus-platform)).
 
+**CAUTION**: Quarkus platform version needs to be set up to 2.11, as later versions use camel-quarkus
+that breaks use of `camel.main.javaRoutesIncludePattern` for integration switching.
+
 See also
 * [Camel Dependency Management](https://camel.apache.org/camel-quarkus/latest/user-guide/dependency-management.html) for Quarkus
 * [Quarkus Platform Guide](https://quarkus.io/guides/platform)

--- a/splunk-quarkus/pom.xml
+++ b/splunk-quarkus/pom.xml
@@ -28,7 +28,7 @@
     <description>Red Hat 3rd party Eventing</description>
 
     <properties>
-        <quarkus.platform.version>2.16.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.11.3.Final</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>


### PR DESCRIPTION
Fix Splunk/SNOW integration switching (using
`camel.main.javaRoutesIncludePattern`) by downgrading Quarkus platform to 2.11.3.Final.
`javaRoutesIncludePattern` property from CLI is was broken in camel-quarkus starting with versions 2.12.0.

References:
* https://camel.apache.org/camel-quarkus/2.16.x/index.html
* https://github.com/apache/camel-quarkus/compare/2.11.0..2.12.0
* https://github.com/apache/camel-quarkus/commit/7d0e3808ffbf4c0e48655f0ac4a041050c24abc4

EVNT-815