### PR TITLE
fix(kafka): sync manual commit

### DIFF
--- a/splunk-quarkus/src/main/resources/application.properties
+++ b/splunk-quarkus/src/main/resources/application.properties
@@ -50,6 +50,9 @@ camel.component.kafka.security-protocol = PLAINTEXT
 camel.component.kafka.ssl-truststore-location =
 camel.component.kafka.ssl-truststore-type = JKS
 camel.component.kafka.max-poll-records = 300
+# https://camel.apache.org/manual/camel-3x-upgrade-guide-3_17.html#_camel_kafka
+camel.component.kafka.allow-manual-commit = true
+camel.component.kafka.kafka-manual-commit-factory = #class:org.apache.camel.component.kafka.consumer.DefaultKafkaManualCommitFactory
 
 
 # Managed Kafka topics


### PR DESCRIPTION
Force to use a sync Kafka commit after each message. Otherwise the auto-commit is done by Kafka lib in a set interval (default 5s).

https://camel.apache.org/manual/camel-3x-upgrade-guide-3_17.html#_camel_kafka

EVNT-820