### PR TITLE
feat(kafka): retry produce and reconnect consumer

### DIFF
--- a/splunk-quarkus/src/main/resources/application.properties
+++ b/splunk-quarkus/src/main/resources/application.properties
@@ -50,6 +50,7 @@ camel.component.kafka.security-protocol = PLAINTEXT
 camel.component.kafka.ssl-truststore-location =
 camel.component.kafka.ssl-truststore-type = JKS
 camel.component.kafka.max-poll-records = 300
+camel.component.kafka.poll-on-error = RECONNECT
 camel.component.kafka.retries = 3
 camel.component.kafka.retry-backoff-ms = 200
 # https://camel.apache.org/manual/camel-3x-upgrade-guide-3_17.html#_camel_kafka

--- a/splunk-quarkus/src/main/resources/application.properties
+++ b/splunk-quarkus/src/main/resources/application.properties
@@ -50,6 +50,8 @@ camel.component.kafka.security-protocol = PLAINTEXT
 camel.component.kafka.ssl-truststore-location =
 camel.component.kafka.ssl-truststore-type = JKS
 camel.component.kafka.max-poll-records = 300
+camel.component.kafka.retries = 3
+camel.component.kafka.retry-backoff-ms = 200
 # https://camel.apache.org/manual/camel-3x-upgrade-guide-3_17.html#_camel_kafka
 camel.component.kafka.allow-manual-commit = true
 camel.component.kafka.kafka-manual-commit-factory = #class:org.apache.camel.component.kafka.consumer.DefaultKafkaManualCommitFactory


### PR DESCRIPTION
Adds 3 retries for Kafka producer with back-off 200ms.
Sets RECONNECT on pollError for Kafka consumer.

https://camel.apache.org/components/3.18.x/kafka-component.html

RHCLOUD-24050