### PR TITLE
[RHCLOUD-24986] refactor: support deserializing incoming "data" JSON objects

### DIFF
--- a/splunk-quarkus/src/main/java/com/redhat/console/integrations/CloudEventDecoder.java
+++ b/splunk-quarkus/src/main/java/com/redhat/console/integrations/CloudEventDecoder.java
@@ -24,8 +24,27 @@ public class CloudEventDecoder implements Processor {
             in.setHeader("Ce-" + key, ceIn.getString(key));
         }
 
+        // Extract the "data" field from the incoming payload. Probably due to
+        // an unintended mistake, the Notifications Engine sends the "data"'s
+        // JSON as a quoted string, instead as a JSON object itself. Our
+        // console.redhat.com CloudEvents specification, which in turn adheres
+        // to the Cloud Events specification, defines the "data" key as a JSON
+        // object[1], and therefore here we attempt to parse it as it is
+        // defined in the specification. However, a fallback of the original
+        // parsing way is left too, in order to avoid breaking the integration
+        // until the bug is fixed in the Notifications Engine. More information
+        // about this can be found in the RHCLOUD-24986[2] Jira ticket.
+        //
+        // [1]: https://github.com/RedHatInsights/event-schemas/blob/4119fc6e3820c6519f8f87abc27cdb4604a80db0/schemas/events/v1/events.json#L58-L59
+        // [2]: https://issues.redhat.com/browse/RHCLOUD-24986
+        JsonObject bodyObject;
+        try {
+            bodyObject = (JsonObject) ceIn.get("data");
+        } catch (final ClassCastException e) {
+            bodyObject = (JsonObject) Jsoner.deserialize(ceIn.getString("data"));
+        }
+
         // Extract metadata, put it in headers and then delete from the body.
-        JsonObject bodyObject = (JsonObject) Jsoner.deserialize(ceIn.getString("data"));
         JsonObject metaData = (JsonObject) bodyObject.get("notif-metadata");
         in.setHeader("metadata", metaData);
         JsonObject extras = (JsonObject) Jsoner.deserialize(metaData.getString("extras"));

--- a/splunk-quarkus/src/test/java/com/redhat/console/integrations/testhelpers/CloudEventTestHelper.java
+++ b/splunk-quarkus/src/test/java/com/redhat/console/integrations/testhelpers/CloudEventTestHelper.java
@@ -100,11 +100,7 @@ public class CloudEventTestHelper {
         cloudEvent.put(FIELD_TIME, TEST_ACTION_TIMESTAMP);
         cloudEvent.put(FIELD_RH_ORG_ID, TEST_ACTION_ORG_ID);
         cloudEvent.put(FIELD_RH_ACCOUNT, TEST_ACTION_ACCOUNT_ID);
-        // The "data" key must go as a string, because due to a bug the
-        // notifications service sends is as such, instead of as a JSON object,
-        // which is what the cloud event schema specification suggests. More
-        // information in https://issues.redhat.com/browse/RHCLOUD-24986.
-        cloudEvent.put(FIELD_DATA, data.toString());
+        cloudEvent.put(FIELD_DATA, data);
 
         return cloudEvent;
     }


### PR DESCRIPTION
Probably due to an unintended mistake, the Notifications Engine sends the "data"'s JSON as a quoted string, instead as a JSON object itself. Our console.redhat.com CloudEvents specification, which in turn adheres to the Cloud Events specification, defines the "data" key as a JSON object[1], and therefore here we attempt to parse it as it is defined in the specification. However, a fallback of the original parsing way is left too, in order to avoid breaking the integration until the bug is fixed in the Notifications Engine. More information about this can be found in the RHCLOUD-24986[2] Jira ticket.

[1]: https://github.com/RedHatInsights/event-schemas/blob/4119fc6e3820c6519f8f87abc27cdb4604a80db0/schemas/events/v1/events.json#L58-L59
[2]: https://issues.redhat.com/browse/RHCLOUD-24986