### PR TITLE
Revert "chore(k8s): lower CPU k8s resources"

### DIFF
--- a/splunk-quarkus/clowdapp.yaml
+++ b/splunk-quarkus/clowdapp.yaml
@@ -81,11 +81,11 @@ parameters:
   - name: ENV_NAME
     required: true
   - name: CPU_LIMIT
-    value: 100m
+    value: 500m
   - name: MEMORY_LIMIT
     value: 512Mi
   - name: CPU_REQUEST
-    value: 10m
+    value: 100m
   - name: MEMORY_REQUEST
     value: 256Mi
   - name: QUARKUS_HTTP_PORT


### PR DESCRIPTION
The app requires much more than 100m CPU to start in stage. It is currently stuck in a restart loop because the health check is not answering. We'll revisit the CPU resources settings later.