### PR TITLE
RHCLOUD-25591 Remove unused HTTP calls to Splunk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 # Ignore generated Quarkus file logs.
 quarkus.log*
 
-# Ignore IntelliJ's IML files.
+# IntelliJ
+*idea/
 *.iml
 
 .DS_Store/

--- a/splunk-quarkus/src/main/java/com/redhat/console/integrations/servicenow/ServiceNowIntegration.java
+++ b/splunk-quarkus/src/main/java/com/redhat/console/integrations/servicenow/ServiceNowIntegration.java
@@ -47,7 +47,7 @@ public class ServiceNowIntegration extends IntegrationsRouteBuilder {
         @Override
         protected void initialize() {
             setLowerCase(true);
-            setFilterOnMatch​(false); // reverse filtering to only accept selected
+            setFilterOnMatch(false); // reverse filtering to only accept selected
 
             getInFilter().clear();
             getOutFilter().clear();

--- a/splunk-quarkus/src/main/java/com/redhat/console/integrations/splunk/SplunkIntegration.java
+++ b/splunk-quarkus/src/main/java/com/redhat/console/integrations/splunk/SplunkIntegration.java
@@ -62,7 +62,7 @@ public class SplunkIntegration extends IntegrationsRouteBuilder {
         @Override
         protected void initialize() {
             setLowerCase(true);
-            setFilterOnMatch​(false); // reverse filtering to only accept selected
+            setFilterOnMatch(false); // reverse filtering to only accept selected
 
             getInFilter().clear();
             getOutFilter().clear();
@@ -127,14 +127,6 @@ public class SplunkIntegration extends IntegrationsRouteBuilder {
                 .setHeader(Exchange.HTTP_URI, header("targetUrl"))
                 .setHeader(Exchange.HTTP_PATH, constant("/services/collector/event"))
                 .choice()
-                .when(simple("${header.targetUrl} startsWith 'http://'"))
-                .to(http("dynamic")
-                        .httpMethod("POST")
-                        .headerFilterStrategy(new SplunkHttpHeaderStrategy())
-                        .advanced()
-                        .httpClientConfigurer(getClientConfigurer()))
-                .endChoice()
-                .otherwise()
                 .when(simple("${headers.metadata[trustAll]} == 'true'"))
                 .to(https("dynamic")
                         .sslContextParameters(getTrustAllCACerts())


### PR DESCRIPTION
[TargetUrlValidator forbids calls to Splunk using the HTTP scheme.](https://github.com/RedHatInsights/eventing-integrations/blob/88d87dd164b8f46a7caa924a45cf625980a5eaf7/splunk-quarkus/src/main/java/com/redhat/console/integrations/TargetUrlValidator.java#L21-L22)

Therefore, we don't need the code that performs that kind of HTTP calls.