### PR TITLE
RHCLOUD-22670 Bump Quarkus to 3.0.3.Final

### DIFF
--- a/splunk-quarkus/pom.xml
+++ b/splunk-quarkus/pom.xml
@@ -28,7 +28,7 @@
     <description>Red Hat 3rd party Eventing</description>
 
     <properties>
-        <quarkus.platform.version>2.11.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>3.0.3.Final</quarkus.platform.version>
         <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
 
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
@@ -123,7 +123,7 @@
         <dependency>
             <groupId>io.quarkiverse.logging.cloudwatch</groupId>
             <artifactId>quarkus-logging-cloudwatch</artifactId>
-            <version>4.3.1</version>
+            <version>6.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
@@ -144,12 +144,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-          <groupId>org.apache.camel</groupId>
-          <artifactId>camel-test-junit5</artifactId>
-          <version>3.17.0</version>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <scope>test</scope>
@@ -158,7 +152,6 @@
             <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-junit5</artifactId>
             <scope>test</scope>
-            <version>2.16.0</version>
         </dependency>
         <dependency>
             <groupId>com.redhat.cloud.common</groupId>
@@ -168,7 +161,7 @@
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-integration-wiremock-support</artifactId>
-            <version>2.16.0</version>
+            <version>3.0.0-M1</version>
             <scope>test</scope>
         </dependency>
 

--- a/splunk-quarkus/src/main/java/com/redhat/console/integrations/ErrorHandlingRoutes.java
+++ b/splunk-quarkus/src/main/java/com/redhat/console/integrations/ErrorHandlingRoutes.java
@@ -16,8 +16,7 @@
  */
 package com.redhat.console.integrations;
 
-import javax.enterprise.context.ApplicationScoped;
-
+import jakarta.enterprise.context.ApplicationScoped;
 import org.apache.camel.LoggingLevel;
 import org.apache.camel.Processor;
 

--- a/splunk-quarkus/src/main/java/com/redhat/console/integrations/MainRoutes.java
+++ b/splunk-quarkus/src/main/java/com/redhat/console/integrations/MainRoutes.java
@@ -1,11 +1,8 @@
 package com.redhat.console.integrations;
 
-import javax.enterprise.context.ApplicationScoped;
-
+import jakarta.enterprise.context.ApplicationScoped;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
-import org.eclipse.microprofile.config.Config;
-import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 @ApplicationScoped

--- a/splunk-quarkus/src/main/java/com/redhat/console/integrations/servicenow/ServiceNowIntegration.java
+++ b/splunk-quarkus/src/main/java/com/redhat/console/integrations/servicenow/ServiceNowIntegration.java
@@ -19,12 +19,11 @@ package com.redhat.console.integrations.servicenow;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
-import javax.enterprise.context.ApplicationScoped;
-
 import com.redhat.console.integrations.BasicAuthenticationProcessor;
 import com.redhat.console.integrations.IntegrationsRouteBuilder;
 import com.redhat.console.integrations.TargetUrlValidator;
 import io.quarkus.runtime.annotations.RegisterForReflection;
+import jakarta.enterprise.context.ApplicationScoped;
 import org.apache.camel.Exchange;
 import org.apache.camel.component.http.HttpClientConfigurer;
 import org.apache.camel.http.base.HttpOperationFailedException;
@@ -89,8 +88,8 @@ public class ServiceNowIntegration extends IntegrationsRouteBuilder {
         from(seda("push").concurrentConsumers(10))
             .to(https("dynamic")
                 .httpMethod("POST")
-                .headerFilterStrategy(new ServiceNowHttpHeaderStrategy())
                 .advanced()
+                .headerFilterStrategy(new ServiceNowHttpHeaderStrategy())
                 .httpClientConfigurer(getClientConfigurer()))
             .to(direct("success"));
     }

--- a/splunk-quarkus/src/main/java/com/redhat/console/integrations/splunk/SplunkIntegration.java
+++ b/splunk-quarkus/src/main/java/com/redhat/console/integrations/splunk/SplunkIntegration.java
@@ -17,12 +17,14 @@
 package com.redhat.console.integrations.splunk;
 
 import java.io.IOException;
-import java.util.HashSet;
 import java.util.concurrent.TimeUnit;
 
-import javax.enterprise.context.ApplicationScoped;
-
+import com.redhat.console.integrations.EventAppender;
+import com.redhat.console.integrations.EventPicker;
+import com.redhat.console.integrations.IntegrationsRouteBuilder;
+import com.redhat.console.integrations.TargetUrlValidator;
 import io.quarkus.runtime.annotations.RegisterForReflection;
+import jakarta.enterprise.context.ApplicationScoped;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.component.http.HttpClientConfigurer;
@@ -32,14 +34,6 @@ import org.apache.camel.model.dataformat.JsonLibrary;
 import org.apache.camel.support.jsse.SSLContextParameters;
 import org.apache.camel.support.jsse.TrustManagersParameters;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
-import org.apache.http.ProtocolException;
-import org.eclipse.microprofile.config.Config;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
-
-import com.redhat.console.integrations.IntegrationsRouteBuilder;
-import com.redhat.console.integrations.TargetUrlValidator;
-import com.redhat.console.integrations.EventAppender;
-import com.redhat.console.integrations.EventPicker;
 
 /**
  * The main class that does the work setting up the Camel routes. Entry point for messages is below
@@ -132,15 +126,15 @@ public class SplunkIntegration extends IntegrationsRouteBuilder {
                         .sslContextParameters(getTrustAllCACerts())
                         .x509HostnameVerifier(NoopHostnameVerifier.INSTANCE)
                         .httpMethod("POST")
-                        .headerFilterStrategy(new SplunkHttpHeaderStrategy())
                         .advanced()
+                        .headerFilterStrategy(new SplunkHttpHeaderStrategy())
                         .httpClientConfigurer(getClientConfigurer()))
                 .endChoice()
                 .otherwise()
                 .to(https("dynamic")
                         .httpMethod("POST")
-                        .headerFilterStrategy(new SplunkHttpHeaderStrategy())
                         .advanced()
+                        .headerFilterStrategy(new SplunkHttpHeaderStrategy())
                         .httpClientConfigurer(getClientConfigurer()))
                 .endChoice()
                 .end()

--- a/splunk-quarkus/src/test/java/com/redhat/console/integrations/CloudEventDecoderTest.java
+++ b/splunk-quarkus/src/test/java/com/redhat/console/integrations/CloudEventDecoderTest.java
@@ -13,6 +13,8 @@ import org.apache.camel.util.json.Jsoner;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+
 @QuarkusTest
 public class CloudEventDecoderTest extends CamelQuarkusTestSupport {
 
@@ -89,7 +91,7 @@ public class CloudEventDecoderTest extends CamelQuarkusTestSupport {
                 "the cloud event's 'specversion' field does not match");
 
         Assertions.assertEquals(
-                CloudEventTestHelper.TEST_ACTION_TIMESTAMP.toString(),
+                CloudEventTestHelper.TEST_ACTION_TIMESTAMP.format(ISO_LOCAL_DATE_TIME),
                 headers.get(String.format("Ce-%s", CloudEventTestHelper.FIELD_TIME)),
                 "the cloud event's 'time' field does not match");
 

--- a/splunk-quarkus/src/test/java/com/redhat/console/integrations/testhelpers/CloudEventTestHelper.java
+++ b/splunk-quarkus/src/test/java/com/redhat/console/integrations/testhelpers/CloudEventTestHelper.java
@@ -17,6 +17,8 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.junit.jupiter.api.Assertions;
 
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+
 public class CloudEventTestHelper {
     /**
      * Cloud event's top level fields.
@@ -167,7 +169,8 @@ public class CloudEventTestHelper {
                 "the 'application' field of the action has an unexpected value");
         Assertions.assertEquals(CloudEventTestHelper.TEST_ACTION_EVENT_TYPE, event.getString("event_type"),
                 "the 'event_type' field of the action has an unexpected value");
-        Assertions.assertEquals(CloudEventTestHelper.TEST_ACTION_TIMESTAMP.toString(), event.getString("timestamp"),
+        Assertions.assertEquals(CloudEventTestHelper.TEST_ACTION_TIMESTAMP.format(ISO_LOCAL_DATE_TIME),
+                event.getString("timestamp"),
                 "the 'timestamp' field of the action has an unexpected value");
         Assertions.assertEquals(CloudEventTestHelper.TEST_ACTION_ORG_ID, event.getString("org_id"),
                 "the 'org_id' field of the action has an unexpected value");
@@ -216,7 +219,8 @@ public class CloudEventTestHelper {
                 "the 'application' field of the action has an unexpected value");
         Assertions.assertEquals(CloudEventTestHelper.TEST_ACTION_EVENT_TYPE, innerEvent.getString("event_type"),
                 "the 'event_type' field of the action has an unexpected value");
-        Assertions.assertEquals(CloudEventTestHelper.TEST_ACTION_TIMESTAMP.toString(), innerEvent.getString("timestamp"),
+        Assertions.assertEquals(CloudEventTestHelper.TEST_ACTION_TIMESTAMP.format(ISO_LOCAL_DATE_TIME),
+                innerEvent.getString("timestamp"),
                 "the 'timestamp' field of the action has an unexpected value");
         Assertions.assertEquals(CloudEventTestHelper.TEST_ACTION_ORG_ID, innerEvent.getString("org_id"),
                 "the 'org_id' field of the action has an unexpected value");


### PR DESCRIPTION
Quarkus `3.0.3.Final` depends on `camel-quarkus:3.0.0-M1` which depends on `camel:4.0.0-M2`. This PR may remain a draft until Quarkus depends on a stable/final release of camel.