### PR TITLE
Prevent NPE while processing latest payloads gen

### DIFF
--- a/splunk-quarkus/src/main/java/com/redhat/console/integrations/CloudEventDecoder.java
+++ b/splunk-quarkus/src/main/java/com/redhat/console/integrations/CloudEventDecoder.java
@@ -46,10 +46,17 @@ public class CloudEventDecoder implements Processor {
 
         // Extract metadata, put it in headers and then delete from the body.
         JsonObject metaData = (JsonObject) bodyObject.get("notif-metadata");
-        in.setHeader("metadata", metaData);
+        if (metaData != null) {
+            in.setHeader("metadata", metaData);
+        }
         JsonObject extras = (JsonObject) Jsoner.deserialize(metaData.getString("extras"));
-        in.setHeader("extras", extras);
-        in.setHeader("accountId", bodyObject.get("account_id"));
+        if (extras != null) {
+            in.setHeader("extras", extras);
+        }
+        Object accountId = bodyObject.get("account_id");
+        if (accountId != null) {
+            in.setHeader("accountId", accountId);
+        }
         in.setHeader("orgId", bodyObject.get("org_id"));
 
         bodyObject.remove("notif-metadata");

--- a/splunk-quarkus/src/main/java/com/redhat/console/integrations/MainRoutes.java
+++ b/splunk-quarkus/src/main/java/com/redhat/console/integrations/MainRoutes.java
@@ -8,7 +8,6 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import static com.redhat.console.integrations.OutgoingCloudEventBuilder.OUTCOME_EXCHANGE_PROPERTY;
 import static com.redhat.console.integrations.OutgoingCloudEventBuilder.SUCCESSFUL_EXCHANGE_PROPERTY;
-import static org.apache.camel.LoggingLevel.INFO;
 
 @ApplicationScoped
 public class MainRoutes extends IntegrationsRouteBuilder {
@@ -47,7 +46,6 @@ public class MainRoutes extends IntegrationsRouteBuilder {
     private void configureIngress() {
         from(kafka(kafkaIngressTopic).groupId(kafkaIngressGroupId))
                 .routeId("ingress")
-                .log(INFO, "Received ${body}") // TODO Temp, remove ASAP
                 // Decode CloudEvent
                 .process(new CloudEventDecoder())
                 // We check that this is our type.


### PR DESCRIPTION
The `platform.notifications.tocamel` topic is temporarily used to produce/consume payloads for multiple integrations, including Slack, Microsoft Teams and Google Chat.

The latest payloads generation caused some `NullPointerException` with the `CloudEventDecoder` logic from this repo. This PR fixes that.