### PR TITLE
RHCLOUD-26617 Use MigrationFilter with ServiceNow

### DIFF
--- a/splunk-quarkus/src/main/java/com/redhat/console/integrations/CloudEventDecoder.java
+++ b/splunk-quarkus/src/main/java/com/redhat/console/integrations/CloudEventDecoder.java
@@ -6,7 +6,7 @@ import org.apache.camel.Processor;
 import org.apache.camel.util.json.JsonObject;
 import org.apache.camel.util.json.Jsoner;
 
-import static com.redhat.console.integrations.splunk.MigrationFilter.KAFKA_PROCESSOR;
+import static com.redhat.console.integrations.MigrationFilter.KAFKA_PROCESSOR;
 
 /**
  * We decode a CloudEvent, set the headers accordingly and put the CE payload as the new body

--- a/splunk-quarkus/src/main/java/com/redhat/console/integrations/MigrationFilter.java
+++ b/splunk-quarkus/src/main/java/com/redhat/console/integrations/MigrationFilter.java
@@ -1,4 +1,4 @@
-package com.redhat.console.integrations.splunk;
+package com.redhat.console.integrations;
 
 import io.quarkus.logging.Log;
 import org.apache.camel.Exchange;

--- a/splunk-quarkus/src/main/java/com/redhat/console/integrations/servicenow/ServiceNowIntegration.java
+++ b/splunk-quarkus/src/main/java/com/redhat/console/integrations/servicenow/ServiceNowIntegration.java
@@ -20,9 +20,11 @@ import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
 
 import com.redhat.console.integrations.BasicAuthenticationProcessor;
 import com.redhat.console.integrations.IntegrationsRouteBuilder;
+import com.redhat.console.integrations.MigrationFilter;
 import com.redhat.console.integrations.TargetUrlValidator;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 import org.apache.camel.Exchange;
@@ -42,6 +44,9 @@ import org.apache.http.auth.AuthenticationException;
 })
 @ApplicationScoped
 public class ServiceNowIntegration extends IntegrationsRouteBuilder {
+
+    @Inject
+    MigrationFilter migrationFilter;
 
     class ServiceNowHttpHeaderStrategy extends HttpHeaderFilterStrategy {
         @Override
@@ -65,6 +70,9 @@ public class ServiceNowIntegration extends IntegrationsRouteBuilder {
     private void configureHandler() {
         from(direct("handler"))
                 .routeId("handler")
+
+                // TODO For migration purposes
+                .filter(migrationFilter)
 
                 //Add properties useful for error reporting and metrics
                 .setProperty("targetUrl", simple("${headers.metadata[url]}"))

--- a/splunk-quarkus/src/main/java/com/redhat/console/integrations/splunk/SplunkIntegration.java
+++ b/splunk-quarkus/src/main/java/com/redhat/console/integrations/splunk/SplunkIntegration.java
@@ -25,6 +25,7 @@ import javax.inject.Inject;
 import com.redhat.console.integrations.EventAppender;
 import com.redhat.console.integrations.EventPicker;
 import com.redhat.console.integrations.IntegrationsRouteBuilder;
+import com.redhat.console.integrations.MigrationFilter;
 import com.redhat.console.integrations.TargetUrlValidator;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 import org.apache.camel.Exchange;


### PR DESCRIPTION
Related to https://github.com/RedHatInsights/notifications-backend/pull/2065.

`MigrationFilter` is used to switch between the Eventing apps and the Notifications connectors for Splunk and ServiceNow.